### PR TITLE
Fix streaming message replacement condition

### DIFF
--- a/refact-agent/engine/python_binding_and_cmdline/refact/cli_streaming.py
+++ b/refact-agent/engine/python_binding_and_cmdline/refact/cli_streaming.py
@@ -133,7 +133,7 @@ def process_streaming_data(data: Dict[str, Any], deltas_collector: Optional[chat
             msg = chat_client.Message.model_validate(data)
 
         replace_last_user = False
-        if msg.role == "user" or msg.role == "system'":
+        if msg.role == "user" or msg.role == "system":
             if len(streaming_messages) > 0:
                 if streaming_messages[-1].role == "user":
                     replace_last_user = True


### PR DESCRIPTION
## Summary
- correct role string check when updating user messages during streaming

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', 'termcolor')*

------
https://chatgpt.com/codex/tasks/task_e_683f664ba0908321a7e01dc0d9474dc9